### PR TITLE
Fix flaky test testValidJSONObject

### DIFF
--- a/src/main/java/com/p2sdev/jsonToOrmMapper/mapper/orm/DjangoModel.java
+++ b/src/main/java/com/p2sdev/jsonToOrmMapper/mapper/orm/DjangoModel.java
@@ -3,6 +3,7 @@ package com.p2sdev.jsonToOrmMapper.mapper.orm;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
 
 import com.p2sdev.jsonToOrmMapper.enums.JSONTypes;
 import com.p2sdev.jsonToOrmMapper.convert.Table;
@@ -79,7 +80,7 @@ public class DjangoModel implements ORM{
 			.append(Model.PRIMARY_KEY.getValue())
 			.append("\n\t");
 		
-		Map<String, JSONTypes> tableColumnsDef = table.getTableColumnsDef();
+		Map<String, JSONTypes> tableColumnsDef = new TreeMap<>(table.getTableColumnsDef());
 		
 		for(String key : tableColumnsDef.keySet()) {
 			switch(tableColumnsDef.get(key)) {

--- a/src/test/java/com/p2sdev/jsonToOrmMapper/AppTest.java
+++ b/src/test/java/com/p2sdev/jsonToOrmMapper/AppTest.java
@@ -63,8 +63,8 @@ public class AppTest
                 " Person(models.Model):" +
                 "person_id = models.AutoField(primary_key=True)" +
                 "f_name = models.CharField(max_length=100)" +
-                "p_id = models.IntegerField()" +
-                "l_name = models.CharField(max_length=100)";
+                "l_name = models.CharField(max_length=100)" +
+                "p_id = models.IntegerField()";
     	
     	expected = expected.replaceAll("\\n|\\r\\n|\\r|\\t", "");
     	


### PR DESCRIPTION
## PR Overview

The PR proposes a fix for the following tests -
[com.p2sdev.jsonToOrmMapper.AppTest#testValidJSONObject
](https://github.com/PSteph/jsonToOrmMapper/blob/b84ba5c14dd40ca9f8556ba7b4bae6e868b3668e/src/test/java/com/p2sdev/jsonToOrmMapper/AppTest.java#L61)

## Build Project

- To build the project :
```
mvn clean install
```
- To run the test :
```
mvn -pl . test
```
- To run the nondex tool on this test :
```
mvn -pl .  edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=<path.to.test#testName>
```
## Problem 
This flakiness was identified by the [nondex tool](https://github.com/TestingResearchIllinois/NonDex) created by the researchers of UIUC. The above eight tests fail when run on the nondex tool.
This test is failing because the order is not maintained in the assertion although it is the same JSON object.

https://github.com/PSteph/jsonToOrmMapper/blob/b84ba5c14dd40ca9f8556ba7b4bae6e868b3668e/src/test/java/com/p2sdev/jsonToOrmMapper/AppTest.java#L61-L69

This problem of flakiness starts with the `JSONToConverter` method that creates the object and builds the fields inside it (called columns here). This is being done when a new `DjangoModel` is being initialized and the function of the class `buildClass` is where the flakiness lies. 

https://github.com/PSteph/jsonToOrmMapper/blob/b84ba5c14dd40ca9f8556ba7b4bae6e868b3668e/src/main/java/com/p2sdev/jsonToOrmMapper/mapper/orm/DjangoModel.java#L82-L89

Here, the `buildClass` function initializes `tableColumnsDef` which is a map, a map does not maintain order which causes the reordering of values and the consequent fail in the assertion.

## Fix:
The proposed fix is to use a TreeMap to maintain the order of insertion. A Treemap is used instead of a LinkedHashMap because to maintain the order of insertion of the nested elements and not only the base-level JSON elements.

Note: There is a change in the base test code, shifting the values of `l_name` and `p_id` to match with the assertion since a TreeMap will maintain order
